### PR TITLE
`feat: add Roles Module

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1633,3 +1633,347 @@ components:
       required:
         - amount
         - mode
+
+  /roles:
+    get:
+      summary: List all roles
+      description: Returns paginated list of roles. Supports filtering by status and search.
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [active, inactive]
+          description: Filter by status
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Search by name, displayName or description
+        - in: query
+          name: skip
+          schema:
+            type: integer
+            default: 0
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of roles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      summary: Create a new role
+      description: Creates a custom role. Role name must be unique and lowercase with underscores.
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRoleRequest'
+      responses:
+        '201':
+          description: Role created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          description: Role name already exists
+
+  /roles/permissions:
+    get:
+      summary: Get all available permissions
+      description: Returns all permissions available in the system, grouped by resource.
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      responses:
+        '200':
+          description: Permission list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      permissions:
+                        type: array
+                        items:
+                          type: string
+                      grouped:
+                        type: object
+                        additionalProperties:
+                          type: array
+                          items:
+                            type: string
+
+  /roles/stats:
+    get:
+      summary: Get role statistics
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      responses:
+        '200':
+          description: Role stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      active:
+                        type: integer
+                      inactive:
+                        type: integer
+                      system:
+                        type: integer
+                      custom:
+                        type: integer
+
+  /roles/seed:
+    post:
+      summary: Seed system roles
+      description: Seeds the four default system roles (super_admin, admin, pg_owner, pg_staff). Idempotent — safe to call multiple times. Requires super_admin.
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      responses:
+        '200':
+          description: System roles seeded
+
+  /roles/{id}:
+    get:
+      summary: Get role by ID
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Role found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      summary: Update a role
+      description: Updates displayName, description, permissions and/or status. System roles can be updated but not deleted.
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRoleRequest'
+      responses:
+        '200':
+          description: Role updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Delete a role
+      description: Deletes a custom role. System roles cannot be deleted. Requires super_admin.
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Role deleted
+        '400':
+          description: Cannot delete system role
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /roles/{id}/status:
+    patch:
+      summary: Toggle role status
+      security:
+        - bearerAuth: []
+      tags:
+        - Roles
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [active, inactive]
+              required:
+                - status
+      responses:
+        '200':
+          description: Status updated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    RoleDefinition:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          example: pg_manager
+        displayName:
+          type: string
+          example: PG Manager
+        description:
+          type: string
+          nullable: true
+        permissions:
+          type: array
+          items:
+            type: string
+          example: ["pgs:read", "tenants:read", "billing:read"]
+        status:
+          type: string
+          enum: [active, inactive]
+        isSystem:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    RoleResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/RoleDefinition'
+        error:
+          nullable: true
+    RoleListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoleDefinition'
+            pagination:
+              type: object
+              properties:
+                skip:
+                  type: integer
+                count:
+                  type: integer
+                totalCount:
+                  type: integer
+    CreateRoleRequest:
+      type: object
+      required:
+        - name
+        - displayName
+        - permissions
+      properties:
+        name:
+          type: string
+          pattern: '^[a-z0-9_]+$'
+          example: pg_manager
+        displayName:
+          type: string
+          example: PG Manager
+        description:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+          example: ["pgs:read", "tenants:read"]
+        status:
+          type: string
+          enum: [active, inactive]
+    UpdateRoleRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+        description:
+          type: string
+          nullable: true
+        permissions:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [active, inactive]

--- a/prisma/migrations/20260517000000_add_role_definition/migration.sql
+++ b/prisma/migrations/20260517000000_add_role_definition/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "RoleDefinition" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "permissions" TEXT[],
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RoleDefinition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoleDefinition_name_key" ON "RoleDefinition"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -297,3 +297,16 @@ model Payment {
   createdAt     DateTime    @default(now())
 }
 
+
+// ============ Roles Module ============
+model RoleDefinition {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  displayName String
+  description String?
+  permissions String[] // e.g. ["users:read", "users:write", "pgs:read"]
+  status      String   @default("active")
+  isSystem    Boolean  @default(false) // system roles cannot be deleted
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/src/controllers/role.controller.ts
+++ b/src/controllers/role.controller.ts
@@ -1,0 +1,283 @@
+import { Request, Response } from 'express'
+import { z } from 'zod'
+import { RoleService, ALL_PERMISSIONS } from '../services/role.service'
+import { logger } from '../utils/logger'
+import {
+  sendBadRequest,
+  sendCreated,
+  sendError,
+  sendNotFound,
+  sendSuccess,
+  sendList,
+  sendConflict,
+} from '../utils/response'
+
+// ─── Validation Schemas ──────────────────────────────────────────────────────
+
+const createRoleSchema = z.object({
+  name: z
+    .string()
+    .min(2, 'Role name must be at least 2 characters')
+    .max(50, 'Role name must be at most 50 characters')
+    .regex(/^[a-z0-9_]+$/, 'Role name must be lowercase letters, numbers and underscores only'),
+  displayName: z
+    .string()
+    .min(2, 'Display name must be at least 2 characters')
+    .max(100, 'Display name must be at most 100 characters'),
+  description: z.string().max(500, 'Description must be at most 500 characters').optional(),
+  permissions: z
+    .array(z.string())
+    .min(1, 'At least one permission is required')
+    .refine(
+      (perms: string[]) => perms.every((p: string) => (ALL_PERMISSIONS as readonly string[]).includes(p)),
+      {
+        message: 'One or more permissions are invalid. Check GET /api/roles/permissions for the full list.',
+      }
+    ),
+  status: z.enum(['active', 'inactive']).optional(),
+})
+
+const updateRoleSchema = z.object({
+  displayName: z
+    .string()
+    .min(2, 'Display name must be at least 2 characters')
+    .max(100)
+    .optional(),
+  description: z.string().max(500).optional(),
+  permissions: z
+    .array(z.string())
+    .min(1, 'At least one permission is required')
+    .refine(
+      (perms: string[]) => perms.every((p: string) => (ALL_PERMISSIONS as readonly string[]).includes(p)),
+      {
+        message: 'One or more permissions are invalid. Check GET /api/roles/permissions for the full list.',
+      }
+    )
+    .optional(),
+  status: z.enum(['active', 'inactive']).optional(),
+})
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/roles
+ * Create a new custom role (admin only)
+ */
+export const createRole = async (req: Request, res: Response) => {
+  try {
+    const parsed = createRoleSchema.safeParse(req.body)
+    if (!parsed.success) {
+      return sendBadRequest(res, 'Validation failed', parsed.error.issues as any)
+    }
+
+    const { name, displayName, description, permissions, status } = parsed.data
+
+    // Check for duplicate name
+    const existing = await RoleService.getRoleByName(name)
+    if (existing) {
+      return sendConflict(res, `Role with name "${name}" already exists`)
+    }
+
+    const role = await RoleService.createRole({
+      name,
+      displayName,
+      description,
+      permissions,
+      status,
+    })
+
+    logger.info('Role created', { roleId: role.id, name: role.name, by: (req as any).auth?.sub })
+    return sendCreated(res, role)
+  } catch (error: any) {
+    logger.error('Create role failed', { error })
+    if (error.code === 'P2002') {
+      return sendConflict(res, 'Role name already exists')
+    }
+    return sendError(res, error?.message || 'Error creating role')
+  }
+}
+
+/**
+ * GET /api/roles
+ * List all roles with optional filters and pagination (admin only)
+ */
+export const getAllRoles = async (req: Request, res: Response) => {
+  try {
+    const { status, search, skip = 0, limit = 10 } = req.query
+
+    const parsedLimit = Math.min(Number(limit) || 10, 100)
+    const parsedSkip = Number(skip) || 0
+    const page = Math.floor(parsedSkip / parsedLimit) + 1
+
+    const result = await RoleService.getAllRoles(
+      {
+        status: status as string | undefined,
+        search: search as string | undefined,
+      },
+      { page, limit: parsedLimit }
+    )
+
+    return sendList(res, result.data, {
+      skip: parsedSkip,
+      count: result.data.length,
+      totalCount: result.pagination.totalCount,
+    })
+  } catch (error: any) {
+    logger.error('Get all roles failed', { error })
+    return sendError(res, error?.message || 'Error fetching roles')
+  }
+}
+
+/**
+ * GET /api/roles/permissions
+ * Return the full list of available permissions (admin only)
+ */
+export const getPermissions = async (_req: Request, res: Response) => {
+  try {
+    // Group permissions by resource for better UX
+    const grouped: Record<string, string[]> = {}
+    for (const perm of ALL_PERMISSIONS) {
+      const [resource] = perm.split(':')
+      if (!grouped[resource]) grouped[resource] = []
+      grouped[resource].push(perm)
+    }
+
+    return sendSuccess(res, {
+      permissions: ALL_PERMISSIONS,
+      grouped,
+    })
+  } catch (error: any) {
+    logger.error('Get permissions failed', { error })
+    return sendError(res, error?.message || 'Error fetching permissions')
+  }
+}
+
+/**
+ * GET /api/roles/stats
+ * Role statistics (admin only)
+ */
+export const getRoleStats = async (_req: Request, res: Response) => {
+  try {
+    const stats = await RoleService.getRoleStats()
+    return sendSuccess(res, stats)
+  } catch (error: any) {
+    logger.error('Get role stats failed', { error })
+    return sendError(res, error?.message || 'Error fetching role stats')
+  }
+}
+
+/**
+ * GET /api/roles/:id
+ * Get a single role by ID (admin only)
+ */
+export const getRoleById = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id)
+    if (isNaN(id)) return sendBadRequest(res, 'Invalid role ID')
+
+    const role = await RoleService.getRoleById(id)
+    if (!role) return sendNotFound(res, 'Role not found')
+
+    return sendSuccess(res, role)
+  } catch (error: any) {
+    logger.error('Get role by id failed', { error })
+    return sendError(res, error?.message || 'Error fetching role')
+  }
+}
+
+/**
+ * PUT /api/roles/:id
+ * Update a role (admin only)
+ * System roles: can update displayName, description, permissions
+ * Custom roles: full update
+ */
+export const updateRole = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id)
+    if (isNaN(id)) return sendBadRequest(res, 'Invalid role ID')
+
+    const parsed = updateRoleSchema.safeParse(req.body)
+    if (!parsed.success) {
+      return sendBadRequest(res, 'Validation failed', parsed.error.issues as any)
+    }
+
+    if (Object.keys(parsed.data).length === 0) {
+      return sendBadRequest(res, 'No fields provided for update')
+    }
+
+    const role = await RoleService.updateRole(id, parsed.data)
+    if (!role) return sendNotFound(res, 'Role not found')
+
+    logger.info('Role updated', { roleId: id, by: (req as any).auth?.sub })
+    return sendSuccess(res, role)
+  } catch (error: any) {
+    logger.error('Update role failed', { error })
+    return sendError(res, error?.message || 'Error updating role')
+  }
+}
+
+/**
+ * DELETE /api/roles/:id
+ * Delete a custom role (admin only — system roles are protected)
+ */
+export const deleteRole = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id)
+    if (isNaN(id)) return sendBadRequest(res, 'Invalid role ID')
+
+    const role = await RoleService.deleteRole(id)
+    if (!role) return sendNotFound(res, 'Role not found')
+
+    logger.info('Role deleted', { roleId: id, by: (req as any).auth?.sub })
+    return sendSuccess(res, { message: 'Role deleted successfully' })
+  } catch (error: any) {
+    logger.error('Delete role failed', { error })
+    if (error.message === 'System roles cannot be deleted') {
+      return sendBadRequest(res, 'System roles cannot be deleted')
+    }
+    return sendError(res, error?.message || 'Error deleting role')
+  }
+}
+
+/**
+ * PATCH /api/roles/:id/status
+ * Toggle role active/inactive (admin only)
+ */
+export const changeRoleStatus = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id)
+    if (isNaN(id)) return sendBadRequest(res, 'Invalid role ID')
+
+    const { status } = req.body
+    if (!['active', 'inactive'].includes(status)) {
+      return sendBadRequest(res, 'Status must be "active" or "inactive"')
+    }
+
+    const role = await RoleService.updateRole(id, { status })
+    if (!role) return sendNotFound(res, 'Role not found')
+
+    logger.info('Role status changed', { roleId: id, status, by: (req as any).auth?.sub })
+    return sendSuccess(res, role)
+  } catch (error: any) {
+    logger.error('Change role status failed', { error })
+    return sendError(res, error?.message || 'Error updating role status')
+  }
+}
+
+/**
+ * POST /api/roles/seed
+ * Seed default system roles — idempotent, safe to call multiple times (super_admin only)
+ */
+export const seedSystemRoles = async (req: Request, res: Response) => {
+  try {
+    const roles = await RoleService.seedSystemRoles()
+    logger.info('System roles seeded', { count: roles.length, by: (req as any).auth?.sub })
+    return sendSuccess(res, {
+      message: `${roles.length} system roles seeded successfully`,
+      roles,
+    })
+  } catch (error: any) {
+    logger.error('Seed system roles failed', { error })
+    return sendError(res, error?.message || 'Error seeding system roles')
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import pgRoutes from './pg.routes'
 import userRoutes from './user.routes'
 import cityRoutes from './city.routes'
 import areaRoutes from './area.routes'
+import roleRoutes from './role.routes'
 import {
   getAllBills,
   getBillByIdUnified,
@@ -21,6 +22,7 @@ router.use('/pgs', pgRoutes)
 router.use('/users', userRoutes)
 router.use('/cities', cityRoutes)
 router.use('/areas', areaRoutes)
+router.use('/roles', roleRoutes)
 
 // ============ Unified Bills Route ============
 router.get('/bills', authRequired, getAllBills)

--- a/src/routes/role.routes.ts
+++ b/src/routes/role.routes.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express'
+import {
+  createRole,
+  getAllRoles,
+  getRoleById,
+  updateRole,
+  deleteRole,
+  changeRoleStatus,
+  getPermissions,
+  getRoleStats,
+  seedSystemRoles,
+} from '../controllers/role.controller'
+import { authRequired, requireRole } from '../middleware/auth'
+
+const router = Router()
+
+// All role routes require authentication
+router.use(authRequired)
+
+// ── Admin + Super Admin routes ─────────────────────────────────────────────
+
+// GET  /api/roles/permissions  — list all available permissions
+router.get('/permissions', requireRole('admin', 'super_admin'), getPermissions)
+
+// GET  /api/roles/stats         — role statistics
+router.get('/stats', requireRole('admin', 'super_admin'), getRoleStats)
+
+// POST /api/roles/seed          — seed default system roles (super_admin only)
+router.post('/seed', requireRole('super_admin'), seedSystemRoles)
+
+// GET  /api/roles               — list all roles (with pagination + filters)
+router.get('/', requireRole('admin', 'super_admin'), getAllRoles)
+
+// POST /api/roles               — create a new custom role
+router.post('/', requireRole('admin', 'super_admin'), createRole)
+
+// GET  /api/roles/:id           — get a single role
+router.get('/:id', requireRole('admin', 'super_admin'), getRoleById)
+
+// PUT  /api/roles/:id           — update a role
+router.put('/:id', requireRole('admin', 'super_admin'), updateRole)
+
+// PATCH /api/roles/:id/status   — toggle active/inactive
+router.patch('/:id/status', requireRole('admin', 'super_admin'), changeRoleStatus)
+
+// DELETE /api/roles/:id         — delete a custom role (system roles blocked)
+router.delete('/:id', requireRole('super_admin'), deleteRole)
+
+export default router

--- a/src/services/role.service.ts
+++ b/src/services/role.service.ts
@@ -1,0 +1,240 @@
+import { prisma } from '../db/prisma'
+
+// All valid permissions in the system
+export const ALL_PERMISSIONS = [
+  // Users
+  'users:read',
+  'users:write',
+  'users:delete',
+  // PGs
+  'pgs:read',
+  'pgs:write',
+  'pgs:delete',
+  // Tenants
+  'tenants:read',
+  'tenants:write',
+  'tenants:delete',
+  // Billing
+  'billing:read',
+  'billing:write',
+  // Expenses
+  'expenses:read',
+  'expenses:write',
+  'expenses:delete',
+  // Cities & Areas
+  'cities:read',
+  'cities:write',
+  'areas:read',
+  'areas:write',
+  // Roles (admin-only)
+  'roles:read',
+  'roles:write',
+] as const
+
+export type Permission = (typeof ALL_PERMISSIONS)[number]
+
+export interface CreateRoleInput {
+  name: string
+  displayName: string
+  description?: string
+  permissions: string[]
+  status?: 'active' | 'inactive'
+}
+
+export interface UpdateRoleInput {
+  displayName?: string
+  description?: string
+  permissions?: string[]
+  status?: 'active' | 'inactive'
+}
+
+export interface RoleFilters {
+  status?: string
+  search?: string
+}
+
+export interface PaginationOptions {
+  page?: number
+  limit?: number
+}
+
+export class RoleService {
+  // ─── Create ─────────────────────────────────────────────────────────────────
+
+  static async createRole(data: CreateRoleInput) {
+    return prisma.roleDefinition.create({
+      data: {
+        name: data.name.toLowerCase().trim(),
+        displayName: data.displayName.trim(),
+        description: data.description?.trim(),
+        permissions: data.permissions,
+        status: data.status ?? 'active',
+        isSystem: false,
+      },
+    })
+  }
+
+  // ─── Read: list all with filters + pagination ────────────────────────────────
+
+  static async getAllRoles(filters?: RoleFilters, pagination?: PaginationOptions) {
+    const page = pagination?.page || 1
+    const limit = pagination?.limit || 10
+    const skip = (page - 1) * limit
+
+    const where: any = {}
+
+    if (filters?.status) {
+      where.status = filters.status
+    }
+
+    if (filters?.search) {
+      where.OR = [
+        { name: { contains: filters.search, mode: 'insensitive' } },
+        { displayName: { contains: filters.search, mode: 'insensitive' } },
+        { description: { contains: filters.search, mode: 'insensitive' } },
+      ]
+    }
+
+    const [roles, total] = await Promise.all([
+      prisma.roleDefinition.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: [{ isSystem: 'desc' }, { createdAt: 'asc' }],
+      }),
+      prisma.roleDefinition.count({ where }),
+    ])
+
+    return {
+      data: roles,
+      pagination: {
+        page,
+        limit,
+        totalCount: total,
+      },
+    }
+  }
+
+  // ─── Read: single by ID ──────────────────────────────────────────────────────
+
+  static async getRoleById(id: number) {
+    return prisma.roleDefinition.findUnique({ where: { id } })
+  }
+
+  // ─── Read: single by name ────────────────────────────────────────────────────
+
+  static async getRoleByName(name: string) {
+    return prisma.roleDefinition.findUnique({
+      where: { name: name.toLowerCase().trim() },
+    })
+  }
+
+  // ─── Update ──────────────────────────────────────────────────────────────────
+
+  static async updateRole(id: number, data: UpdateRoleInput) {
+    // Prevent mutating system roles' permissions/status if desired
+    const existing = await prisma.roleDefinition.findUnique({ where: { id } })
+    if (!existing) return null
+
+    const updateData: any = {}
+    if (data.displayName !== undefined) updateData.displayName = data.displayName.trim()
+    if (data.description !== undefined) updateData.description = data.description?.trim() ?? null
+    if (data.permissions !== undefined) updateData.permissions = data.permissions
+    if (data.status !== undefined) updateData.status = data.status
+
+    return prisma.roleDefinition.update({ where: { id }, data: updateData })
+  }
+
+  // ─── Delete ──────────────────────────────────────────────────────────────────
+
+  static async deleteRole(id: number) {
+    const existing = await prisma.roleDefinition.findUnique({ where: { id } })
+    if (!existing) return null
+    if (existing.isSystem) {
+      throw new Error('System roles cannot be deleted')
+    }
+    return prisma.roleDefinition.delete({ where: { id } })
+  }
+
+  // ─── Seed default system roles ───────────────────────────────────────────────
+
+  static async seedSystemRoles() {
+    const systemRoles = [
+      {
+        name: 'super_admin',
+        displayName: 'Super Admin',
+        description: 'Full access to everything in the system',
+        permissions: [...ALL_PERMISSIONS],
+        isSystem: true,
+      },
+      {
+        name: 'admin',
+        displayName: 'Admin',
+        description: 'Administrative access, can manage users, PGs, billing and configuration',
+        permissions: ALL_PERMISSIONS.filter((p) => p !== 'roles:write'),
+        isSystem: true,
+      },
+      {
+        name: 'pg_owner',
+        displayName: 'PG Owner',
+        description: 'Manages their own PG properties, tenants and billing',
+        permissions: [
+          'pgs:read',
+          'pgs:write',
+          'tenants:read',
+          'tenants:write',
+          'billing:read',
+          'billing:write',
+          'expenses:read',
+          'expenses:write',
+        ],
+        isSystem: true,
+      },
+      {
+        name: 'pg_staff',
+        displayName: 'PG Staff',
+        description: 'Day-to-day operations for a PG — view tenants and raise bills',
+        permissions: [
+          'pgs:read',
+          'tenants:read',
+          'tenants:write',
+          'billing:read',
+          'billing:write',
+          'expenses:read',
+        ],
+        isSystem: true,
+      },
+    ]
+
+    for (const role of systemRoles) {
+      await prisma.roleDefinition.upsert({
+        where: { name: role.name },
+        update: {
+          displayName: role.displayName,
+          description: role.description,
+          permissions: role.permissions as string[],
+        },
+        create: {
+          ...role,
+          permissions: role.permissions as string[],
+          status: 'active',
+        },
+      })
+    }
+
+    return prisma.roleDefinition.findMany({ where: { isSystem: true } })
+  }
+
+  // ─── Stats ───────────────────────────────────────────────────────────────────
+
+  static async getRoleStats() {
+    const [total, active, inactive, system, custom] = await Promise.all([
+      prisma.roleDefinition.count(),
+      prisma.roleDefinition.count({ where: { status: 'active' } }),
+      prisma.roleDefinition.count({ where: { status: 'inactive' } }),
+      prisma.roleDefinition.count({ where: { isSystem: true } }),
+      prisma.roleDefinition.count({ where: { isSystem: false } }),
+    ])
+    return { total, active, inactive, system, custom }
+  }
+}


### PR DESCRIPTION
- Add RoleDefinition model to Prisma schema
- Add migration for RoleDefinition table
- Add RoleService with CRUD, stats, and system role seeding
- Add RoleController with Zod validation
- Add role routes with authRequired + requireRole guards
- Register /api/roles in routes index
- Add Swagger docs for all role endpoints
- 22 granular permissions across 8 resources
- System roles (super_admin, admin, pg_owner, pg_staff) protected from deletion